### PR TITLE
Handle custom publish buckets

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -41,5 +41,6 @@ COPY --from=build lambda .
 
 COPY test.py .
 COPY test.txt .
+COPY pytest.ini .
 
 CMD ["python3", "-m", "pytest", "-s", "test.py"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,9 @@ services:
       AWS_DEFAULT_REGION: 'us-east-1'
 
   localstack:
-    image: localstack/localstack
+    image: localstack/localstack:1.1.0
     environment:
-      SERVICES: s3
+      - MAIN_CONTAINER_NAME=localstack
+      - SERVICES=s3
     expose:
-      - "4572"
+      - "4566"

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ TIER = os.environ['TIER']
 FULL_SERVICE_NAME = f'{SERVICE_NAME}-{TIER}'
 
 if ENVIRONMENT == 'local':
-    S3_URL = 'http://localstack:4572'
+    S3_URL = 'http://localstack:4566'
 else:
     S3_URL = None
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+# deprecation warning from third party code
+    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working:DeprecationWarning:botocore:

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -17,7 +17,6 @@ resource "aws_lambda_function" "discover_s3clean_lambda_function" {
       ENVIRONMENT               = var.environment_name
       SERVICE_NAME              = var.service_name
       TIER                      = var.tier
-      PUBLISH_BUCKET            = data.terraform_remote_state.platform_infrastructure.outputs.discover_publish_bucket_id
       EMBARGO_BUCKET            = data.terraform_remote_state.platform_infrastructure.outputs.discover_embargo_bucket_id
       ASSET_BUCKET              = data.terraform_remote_state.platform_infrastructure.outputs.discover_s3_bucket_id
       DATASET_ASSETS_KEY_PREFIX = data.terraform_remote_state.platform_infrastructure.outputs.discover_bucket_dataset_assets_key_prefix


### PR DESCRIPTION
To handle custom publish buckets this PR gets the name of the publish bucket from the triggering event instead of reading it from an environment variable.

The PR also sets `RequestPayer` to `requester` for S3 requests involving the publish bucket.
