### PR TITLE
Remove terraform/providers.tf

### DIFF
--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -1,5 +1,0 @@
-//DEFINE PROVIDER
-provider "aws" {
-  profile = var.aws_account
-  region  = var.aws_region
-}


### PR DESCRIPTION
Removing a Terraform file that is no longer required and breaks`terraform.sh plan`.