### PR TITLE
Include publish and embargo bucket names in lambda event

### DIFF
--- a/main.py
+++ b/main.py
@@ -55,13 +55,13 @@ def lambda_handler(event, context, s3_client=S3_CLIENT, s3_paginator=PAGINATOR):
 
     try:
         log.info('Reading environment')
-        embargo_bucket_id = os.environ['EMBARGO_BUCKET']
         asset_bucket_id = os.environ['ASSET_BUCKET']
         assets_prefix = os.environ['DATASET_ASSETS_KEY_PREFIX']
 
         log.info('Parsing event')
 
-        publish_bucket_id = event['s3_bucket']
+        publish_bucket_id = event['publish_bucket']
+        embargo_bucket_id = event['embargo_bucket']
 
         # Ensure the S3 key ends with a '/'
         if event['s3_key_prefix'].endswith('/'):
@@ -78,7 +78,8 @@ def lambda_handler(event, context, s3_client=S3_CLIENT, s3_paginator=PAGINATOR):
         log = log.bind(
             pennsieve={
                 'service_name': FULL_SERVICE_NAME,
-                's3_bucket': publish_bucket_id,
+                'publish_bucket': publish_bucket_id,
+                'embargo_bucket': embargo_bucket_id,
                 's3_key_prefix': s3_key_prefix
             },
         )
@@ -89,7 +90,7 @@ def lambda_handler(event, context, s3_client=S3_CLIENT, s3_paginator=PAGINATOR):
         delete(s3_client, s3_paginator, publish_bucket_id, s3_key_prefix, is_requester_pays=True)
 
         log.info('Deleting objects from bucket {} under key {}'.format(embargo_bucket_id, s3_key_prefix))
-        delete(s3_client, s3_paginator, embargo_bucket_id, s3_key_prefix)
+        delete(s3_client, s3_paginator, embargo_bucket_id, s3_key_prefix, is_requester_pays=True)
 
         log.info('Deleting objects from bucket {} under key {}'.format(asset_bucket_id, dataset_assets_prefix))
         delete(s3_client, s3_paginator, asset_bucket_id, dataset_assets_prefix)

--- a/terraform/lambda.tf
+++ b/terraform/lambda.tf
@@ -17,7 +17,6 @@ resource "aws_lambda_function" "discover_s3clean_lambda_function" {
       ENVIRONMENT               = var.environment_name
       SERVICE_NAME              = var.service_name
       TIER                      = var.tier
-      EMBARGO_BUCKET            = data.terraform_remote_state.platform_infrastructure.outputs.discover_embargo_bucket_id
       ASSET_BUCKET              = data.terraform_remote_state.platform_infrastructure.outputs.discover_s3_bucket_id
       DATASET_ASSETS_KEY_PREFIX = data.terraform_remote_state.platform_infrastructure.outputs.discover_bucket_dataset_assets_key_prefix
     }


### PR DESCRIPTION
The lambda event must include both the publish and embargo bucket names, since both will be part of a custom bucket configuration for an organization.