### PR TITLE
implement cleanup of Model Metadata files on new publication

### DIFF
--- a/main.py
+++ b/main.py
@@ -78,7 +78,7 @@ DatasetAssetsKey = "publish.json"
 GraphAssetsKey = "graph.json"
 OutputAssetsKey = "outputs.json"
 RevisionsCleanupKey = "revisions-cleanup.json"
-MetadataCleanupKey = "model-metadata-cleanup.json"
+MetadataCleanupKey = "metadata-cleanup.json"
 
 RevisionsPrefix = "revisions"
 MetadataPrefix = "metadata"


### PR DESCRIPTION
- delete files in `metadata` directory (S3 will place a DeleteMarker)
- record an "evidence" file (for undo/rollback on publishing failure)