### PR TITLE
Update Python Runtime

### DIFF
--- a/main.py
+++ b/main.py
@@ -213,6 +213,7 @@ def lambda_handler(event, context, s3_client=S3Client, s3_paginator=S3ClientPagi
     log = log.bind(pennsieve={'service_name': FULL_SERVICE_NAME})
 
     try:
+        log.info(f"boto3 version: {boto3.__version__}")
         log.info('Reading environment')
         asset_bucket_id = os.environ['ASSET_BUCKET']
         assets_prefix = os.environ['DATASET_ASSETS_KEY_PREFIX']

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -17,7 +17,7 @@ variable "service_name" {}
 variable "tier" {}
 
 variable "runtime" {
-  default = "python3.9"
+  default = "python3.12"
 }
 
 variable "bucket" {


### PR DESCRIPTION
There appears to be some incompatibility with the version of boto3 with the deployed Lambda. Calls to `pagination.paginate()` were failing with the complaint:

```
ParamValidationError('Parameter validation failed:\\nUnknown parameter in input: \"RequestPayer\", must be one of: Bucket, Delimiter, EncodingType, KeyMarker, MaxKeys, Prefix, VersionIdMarker, ExpectedBucketOwner')
```

- Added logging of the boto3 version at startup to show which version was installed with the Lambda.
- updated to the latest Lambda Python runtime: Python 3.12

Note: manually tested in AWS Console, and it looks like the change should fix the problem.