### PR TITLE
Grant access to AWS Open Data S3 Bucket (for SPARC)

### DIFF
--- a/terraform/iam.tf
+++ b/terraform/iam.tf
@@ -119,6 +119,8 @@ data "aws_iam_policy_document" "lambda_iam_policy_document" {
       "${data.terraform_remote_state.africa_south_region.outputs.af_south_s3_discover_bucket_arn}/*",
       data.terraform_remote_state.africa_south_region.outputs.af_south_s3_embargo_bucket_arn,
       "${data.terraform_remote_state.africa_south_region.outputs.af_south_s3_embargo_bucket_arn}/*",
+      data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_arn,
+      "${data.terraform_remote_state.platform_infrastructure.outputs.awsod_sparc_publish50_bucket_arn}/*"
     ]
   }
 }


### PR DESCRIPTION
Update IAM Policy to grant access to AWS Open Data S3 Bucket (for SPARC).