### PR TITLE
Fix unpublish

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,4 @@ docs/doctrees
 
 # profiling
 *.dat
+/discover-s3clean-*.zip

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazonlinux:latest as build
+FROM amazonlinux:latest AS build
 
 RUN yum -y install git \
     findutils \
@@ -8,7 +8,7 @@ RUN yum -y install git \
     unzip && \
     yum clean all
 
-RUN python3 -m pip install boto3==1.9.42
+RUN python3 -m pip install boto3==1.40.21
 
 WORKDIR lambda
 RUN mkdir bin
@@ -21,7 +21,7 @@ COPY main.py .
 RUN zip -r lambda.zip .
 
 
-FROM amazonlinux:latest as test
+FROM amazonlinux:latest AS test
 
 RUN yum -y install git \
     findutils \
@@ -30,7 +30,7 @@ RUN yum -y install git \
     zip && \
     yum clean all
 
-RUN python3 -m pip install boto3==1.9.42
+RUN python3 -m pip install boto3==1.40.21
 
 WORKDIR lambda
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,19 +2,21 @@ FROM amazonlinux:latest AS build
 
 RUN yum -y install git \
     findutils \
-    python39 \
-    python-pip \
+    python3.12 \
+    python3.12-pip \
     zip \
     unzip && \
     yum clean all
 
-RUN python3 -m pip install boto3==1.40.21
+
+# python3 points to the system python which now is 3.9, not the python 3.12 we just installed
+RUN python3.12 -m pip install boto3==1.40.21
 
 WORKDIR lambda
 RUN mkdir bin
 
 COPY requirements.txt .
-RUN python3 -m pip install -r requirements.txt --target .
+RUN python3.12 -m pip install -r requirements.txt --target .
 RUN find . -name "*.pyc" -delete
 
 COPY main.py .
@@ -25,22 +27,22 @@ FROM amazonlinux:latest AS test
 
 RUN yum -y install git \
     findutils \
-    python39 \
-    python-pip \
+    python3.12 \
+    python3.12-pip \
     zip && \
     yum clean all
 
-RUN python3 -m pip install boto3==1.40.21
+
+RUN python3.12 -m pip install boto3==1.40.21
 
 WORKDIR lambda
 
 COPY requirements-test.txt .
-RUN python3 -m pip install -r requirements-test.txt
+RUN python3.12 -m pip install -r requirements-test.txt
 
 COPY --from=build lambda .
 
 COPY test.py .
 COPY test.txt .
-COPY pytest.ini .
 
-CMD ["python3", "-m", "pytest", "-s", "test.py"]
+CMD ["python3.12", "-m", "pytest", "-s", "test.py"]

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -13,13 +13,13 @@ node('executor') {
     env.ENVIRONMENT = "local"
 
     try {
-        // stage("Run Tests") {
-        //     try {
-        //         sh "make test"
-        //     } finally {
-        //         sh "make clean"
-        //     }
-        // }
+         stage("Run Tests") {
+             try {
+                 sh "make test"
+             } finally {
+                 sh "make clean"
+             }
+         }
 
         if(isMain) {
             stage ('Build and Push') {

--- a/Makefile
+++ b/Makefile
@@ -11,15 +11,15 @@ PACKAGE_NAME  ?= ${PACKAGE_BASE}-${VERSION}.zip
 PACKAGE_ZIP   ?= $(WORKING_DIR)/$(PACKAGE_NAME)
 
 clean:
-	docker-compose down --volumes
+	docker compose down --volumes
 
 test:
 	@echo "Testing..."
-	docker-compose stop
-	docker-compose rm -f
-	docker-compose build test
-	docker-compose up --exit-code-from test test
-	docker-compose stop
+	docker compose stop
+	docker compose rm -f
+	docker compose build test
+	docker compose up --exit-code-from test test
+	docker compose stop
 
 package:
 	@echo "Building lambda..."

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,9 +16,8 @@ services:
       AWS_DEFAULT_REGION: 'us-east-1'
 
   localstack:
-    image: localstack/localstack:1.1.0
+    image: localstack/localstack:s3-latest
     environment:
       - MAIN_CONTAINER_NAME=localstack
-      - SERVICES=s3
     expose:
       - "4566"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     depends_on:
       - localstack
     environment:
-      ENVIRONMENT: local
+      ENVIRONMENT: docker
       SERVICE_NAME: discover
       TIER: s3clean
       AWS_ACCESS_KEY_ID: xxxx

--- a/main.py
+++ b/main.py
@@ -7,6 +7,7 @@ from botocore.exceptions import ClientError
 
 import structlog
 
+
 @dataclass
 class S3CleanConfig:
     """S3 Clean Invocation Config"""
@@ -21,6 +22,7 @@ class S3CleanConfig:
     dataset_version: str
     tidy_enabled: bool
 
+
 class WithLogging:
     def logger(class_name):
         log = structlog.get_logger()
@@ -28,30 +30,30 @@ class WithLogging:
         log.bind(pennsieve={'service_name': class_name})
         return log
 
+
 class RequestPayer:
-    def __init__(self, is_requestor_pays = True):
+    def __init__(self, is_requestor_pays=True):
         self.is_requestor_pays = is_requestor_pays
 
     def __call__(self):
         return {'RequestPayer': 'requester'} if self.is_requestor_pays else {}
 
+
 class S3Paginator:
     log = WithLogging.logger('S3Paginator')
-    s3 = boto3.client("s3")
-    paginator = None
-    requestor_pays = None
 
-    def init(paginator, is_requestor_pays = True):
+    def __init__(self, paginator, is_requestor_pays=True):
         S3Paginator.log.info(f"init() is_requestor_pays: {is_requestor_pays}")
-        S3Paginator.requestor_pays = RequestPayer(is_requestor_pays)
-        S3Paginator.paginator = paginator
+        self.requestor_pays = RequestPayer(is_requestor_pays)
+        self.wrapped_paginator = paginator
 
-    def paginate(Bucket, Prefix, PaginationConfig={'PageSize': 1000}, **kwargs):
+    def paginate(self, Bucket, Prefix, PaginationConfig={'PageSize': 1000}, **kwargs):
         S3Paginator.log.info(f"paginate() Bucket: {Bucket} Prefix: {Prefix} PaginationConfig: {PaginationConfig}")
-        return S3Paginator.paginator.paginate(Bucket=Bucket,
-                                              Prefix=Prefix,
-                                              PaginationConfig=PaginationConfig,
-                                              **S3Paginator.requestor_pays())
+        return self.wrapped_paginator.paginate(Bucket=Bucket,
+                                               Prefix=Prefix,
+                                               PaginationConfig=PaginationConfig,
+                                               **self.requestor_pays())
+
 
 class S3Client:
     log = WithLogging.logger('S3Client')
@@ -59,7 +61,7 @@ class S3Client:
     is_requestor_pays = True
     requestor_pays = None
 
-    def init(endpoint_url = None, is_requestor_pays = True):
+    def init(endpoint_url=None, is_requestor_pays=True):
         S3Client.log.info(f"init() is_requestor_pays: {is_requestor_pays}")
         S3Client.is_requestor_pays = is_requestor_pays
         S3Client.requestor_pays = RequestPayer(is_requestor_pays)
@@ -67,9 +69,8 @@ class S3Client:
 
     def get_paginator(operation_name):
         S3Client.log.info(f"get_paginator() operation_name: {operation_name}")
-        S3Paginator.init(S3Client.s3.get_paginator(operation_name),
-                         S3Client.is_requestor_pays)
-        return S3Paginator
+        return S3Paginator(S3Client.s3.get_paginator(operation_name),
+                           S3Client.is_requestor_pays)
 
     def list_object_versions(Bucket, Prefix):
         S3Client.log.info(f"list_object_versions() Bucket: {Bucket} Prefix: {Prefix}")
@@ -106,6 +107,7 @@ class S3Client:
         S3Client.log.info(f"delete_objects() Bucket: {Bucket} number-of-items: {len(Delete)}")
         return S3Client.s3.delete_objects(Bucket=Bucket, Delete=Delete, **S3Client.requestor_pays())
 
+
 # Configure JSON logs in a format that ELK can understand
 # --------------------------------------------------
 def rewrite_event_to_message(logger, name, event_dict):
@@ -139,8 +141,10 @@ SERVICE_NAME = os.environ['SERVICE_NAME']
 TIER = os.environ['TIER']
 FULL_SERVICE_NAME = f'{SERVICE_NAME}-{TIER}'
 
-if ENVIRONMENT == 'local':
+if ENVIRONMENT == 'docker':
     S3_URL = 'http://localstack:4566'
+elif ENVIRONMENT == 'local':
+    S3_URL = 'http://localhost:4566'
 else:
     S3_URL = None
 
@@ -194,11 +198,13 @@ PublishingIntermediateFiles = [FileActionKey,
                                MetadataCleanupKey,
                                ReleaseAssetsListing]
 
+
 def str_to_bool(s):
     if s is not None:
         return s.upper() == "TRUE"
     else:
         return False
+
 
 def is_tidy_enabled(tidy_enabled_evt, tidy_enabled_env):
     if tidy_enabled_evt is not None:
@@ -207,6 +213,7 @@ def is_tidy_enabled(tidy_enabled_evt, tidy_enabled_env):
         return str_to_bool(tidy_enabled_env)
     else:
         return Default_TidyEnabled
+
 
 def lambda_handler(event, context, s3_client=S3Client, s3_paginator=S3ClientPaginator):
     # Create basic Pennsieve log context
@@ -219,7 +226,7 @@ def lambda_handler(event, context, s3_client=S3Client, s3_paginator=S3ClientPagi
         log.info('Reading environment')
         asset_bucket_id = os.environ['ASSET_BUCKET']
         assets_prefix = os.environ['DATASET_ASSETS_KEY_PREFIX']
-        tidy_enabled_env = os.environ.get("TIDY_ENABLED","TRUE")
+        tidy_enabled_env = os.environ.get("TIDY_ENABLED", "TRUE")
 
         log.info('Parsing event')
 
@@ -228,13 +235,15 @@ def lambda_handler(event, context, s3_client=S3Client, s3_paginator=S3ClientPagi
         s3_key_prefix = event.get('s3_key_prefix', "-1")
         cleanup_stage = event.get("cleanup_stage", CleanupStageInitial)
         workflow_id = int(event.get("workflow_id", "4"))
-        dataset_id = event.get("published_dataset_id","-1")
+        dataset_id = event.get("published_dataset_id", "-1")
         dataset_version = event.get("published_dataset_version", "-1")
         tidy_enabled_evt = event.get("tidy_enabled")
 
         tidy_enabled = is_tidy_enabled(tidy_enabled_evt, tidy_enabled_env)
 
-        s3_clean_config = S3CleanConfig(asset_bucket_id, assets_prefix, publish_bucket_id, embargo_bucket_id, s3_key_prefix, cleanup_stage, workflow_id, dataset_id, dataset_version, tidy_enabled)
+        s3_clean_config = S3CleanConfig(asset_bucket_id, assets_prefix, publish_bucket_id, embargo_bucket_id,
+                                        s3_key_prefix, cleanup_stage, workflow_id, dataset_id, dataset_version,
+                                        tidy_enabled)
 
         if workflow_id == 5:
             purge_v5(log, s3_client, s3_paginator, s3_clean_config)
@@ -242,14 +251,18 @@ def lambda_handler(event, context, s3_client=S3Client, s3_paginator=S3ClientPagi
             if cleanup_stage == CleanupStageTidy:
                 tidy_v4(log, tidy_enabled, s3_client, publish_bucket_id, embargo_bucket_id, s3_key_prefix)
             else:
-                purge_v4(log, asset_bucket_id, assets_prefix, publish_bucket_id, embargo_bucket_id, s3_key_prefix, s3_client, s3_paginator)
+                purge_v4(log, asset_bucket_id, assets_prefix, publish_bucket_id, embargo_bucket_id, s3_key_prefix,
+                         s3_client, s3_paginator)
 
     except Exception as e:
         log.error(e, exc_info=True)
         raise
 
-def purge_v4(log, asset_bucket_id, assets_prefix, publish_bucket_id, embargo_bucket_id, s3_key_prefix_evt, s3_client, s3_paginator):
-    log.info(f"purge_v4() asset_bucket_id: {asset_bucket_id} assets_prefix: {assets_prefix} publish_bucket_id: {publish_bucket_id} embargo_bucket_id: {embargo_bucket_id} s3_key_prefix_evt: {s3_key_prefix_evt}")
+
+def purge_v4(log, asset_bucket_id, assets_prefix, publish_bucket_id, embargo_bucket_id, s3_key_prefix_evt, s3_client,
+             s3_paginator):
+    log.info(
+        f"purge_v4() asset_bucket_id: {asset_bucket_id} assets_prefix: {assets_prefix} publish_bucket_id: {publish_bucket_id} embargo_bucket_id: {embargo_bucket_id} s3_key_prefix_evt: {s3_key_prefix_evt}")
     try:
         # Ensure the S3 key ends with a '/'
         if s3_key_prefix_evt.endswith('/'):
@@ -275,14 +288,17 @@ def purge_v4(log, asset_bucket_id, assets_prefix, publish_bucket_id, embargo_buc
         log.error(e, exc_info=True)
         raise
 
+
 def tidy_v4(log, tidy_enabled, s3_client, publish_bucket_id, embargo_bucket_id, s3_key_prefix):
-    log.info(f"tidy_v4() tidy_enabled: {tidy_enabled} publish_bucket_id: {publish_bucket_id} embargo_bucket_id: {embargo_bucket_id} s3_key_prefix: {s3_key_prefix}")
+    log.info(
+        f"tidy_v4() tidy_enabled: {tidy_enabled} publish_bucket_id: {publish_bucket_id} embargo_bucket_id: {embargo_bucket_id} s3_key_prefix: {s3_key_prefix}")
     if tidy_enabled:
         log.info(f"tidy_v4() removing intermediate publishing files")
         for bucket_id in [publish_bucket_id, embargo_bucket_id]:
             tidy_publication_directory(log, s3_client, bucket_id, s3_key_prefix)
     else:
         log.info(f"tidy_v4() requested but disabled")
+
 
 def delete(s3_client, s3_paginator, bucket, prefix, is_requester_pays=False):
     requester_pays = {'RequestPayer': 'requester'} if is_requester_pays else {}
@@ -307,6 +323,7 @@ def delete(s3_client, s3_paginator, bucket, prefix, is_requester_pays=False):
             if len(items_to_delete['Objects']):
                 s3_client.delete_objects(Bucket=bucket, Delete=items_to_delete, **requester_pays)
 
+
 def purge_v5(log, s3_client, s3_paginator, s3_clean_config):
     log.info(f"purge_v5() {s3_clean_config.cleanup_stage} config: {s3_clean_config}")
 
@@ -322,10 +339,12 @@ def purge_v5(log, s3_client, s3_paginator, s3_clean_config):
     if s3_clean_config.cleanup_stage == CleanupStageFailure:
         purge_v5_failure(log, s3_client, s3_paginator, s3_clean_config)
 
+
 def purge_v5_initial(log, s3_client, s3_clean_config):
     log.info(f"purge_v5_initial() preparing space for publication")
     cleanup_dataset_revisions(log, s3_client, s3_clean_config)
     cleanup_dataset_metadata(log, s3_client, s3_clean_config)
+
 
 def purge_v5_tidy(log, s3_client, s3_clean_config):
     if s3_clean_config.tidy_enabled:
@@ -334,6 +353,7 @@ def purge_v5_tidy(log, s3_client, s3_clean_config):
             tidy_publication_directory(log, s3_client, bucket_id, s3_clean_config.s3_key_prefix)
     else:
         log.info(f"purge_v5_tidy() requested but disabled")
+
 
 def purge_v5_unpublish(log, s3_client, s3_paginator, s3_clean_config):
     log.info(f"purge_v5_unpublish() will remove all versions and all files")
@@ -349,6 +369,7 @@ def purge_v5_unpublish(log, s3_client, s3_paginator, s3_clean_config):
                                  s3_clean_config.assets_prefix,
                                  s3_clean_config.dataset_id,
                                  None)
+
 
 def purge_v5_failure(log, s3_client, s3_paginator, s3_clean_config):
     log.info(f"purge_v5_failure() undo publishing actions and clean public assets bucket")
@@ -370,6 +391,7 @@ def purge_v5_failure(log, s3_client, s3_paginator, s3_clean_config):
                                  s3_clean_config.dataset_id,
                                  s3_clean_config.dataset_version)
 
+
 def cleanup_dataset_revisions(log, s3_client, s3_clean_config):
     log.info(f"cleanup_dataset_revisions() {s3_clean_config.dataset_id}")
     cleanup_dataset_folders(log,
@@ -378,6 +400,7 @@ def cleanup_dataset_revisions(log, s3_client, s3_clean_config):
                             s3_clean_config.dataset_id,
                             RevisionsPrefix,
                             RevisionsCleanupKey)
+
 
 def cleanup_dataset_metadata(log, s3_client, s3_clean_config):
     log.info(f"cleanup_dataset_metadata() {s3_clean_config.dataset_id}")
@@ -388,8 +411,10 @@ def cleanup_dataset_metadata(log, s3_client, s3_clean_config):
                             MetadataPrefix,
                             MetadataCleanupKey)
 
+
 def cleanup_dataset_folders(log, s3_client, bucket_list, dataset_id, folder_prefix, folder_cleanup_key):
-    log.info(f"cleanup_dataset_folders() dataset_id: {dataset_id} folder_prefix: {folder_prefix} folder_cleanup_key: {folder_cleanup_key} bucket_list: {bucket_list}")
+    log.info(
+        f"cleanup_dataset_folders() dataset_id: {dataset_id} folder_prefix: {folder_prefix} folder_cleanup_key: {folder_cleanup_key} bucket_list: {bucket_list}")
     key_prefix = f"{dataset_id}/{folder_prefix}"
     cleanup_file = f"{dataset_id}/{folder_cleanup_key}" if folder_cleanup_key is not None else None
     cleanup_buckets(log,
@@ -398,6 +423,7 @@ def cleanup_dataset_folders(log, s3_client, bucket_list, dataset_id, folder_pref
                     key_prefix,
                     cleanup_file)
 
+
 def cleanup_buckets(log, s3_client, bucket_list, key_prefix, cleanup_file):
     log.info(f"cleanup_buckets() key_prefix: {key_prefix} cleanup_file: {cleanup_file} bucket_list: {bucket_list}")
 
@@ -405,8 +431,10 @@ def cleanup_buckets(log, s3_client, bucket_list, key_prefix, cleanup_file):
         log.info(f"cleanup_buckets() processing bucket_id: {bucket_id}")
         file_actions = remove_files_from_bucket(log, s3_client, bucket_id, key_prefix)
         if file_actions is not None and len(file_actions.get(FileActionListTag, [])) > 0:
-            log.info(f"cleanup_buckets() bucket_id: {bucket_id} cleaned up {len(file_actions.get(FileActionListTag))} files")
+            log.info(
+                f"cleanup_buckets() bucket_id: {bucket_id} cleaned up {len(file_actions.get(FileActionListTag))} files")
             write_json_file_to_s3(log, s3_client, bucket_id, cleanup_file, json.dumps(file_actions))
+
 
 def remove_files_from_bucket(log, s3_client, bucket_id, key_prefix):
     log.info(f"remove_files_from_bucket() bucket_id: {bucket_id} key_prefix: {key_prefix}")
@@ -416,10 +444,13 @@ def remove_files_from_bucket(log, s3_client, bucket_id, key_prefix):
     file_action_list = [remove_file(log, s3_client, bucket_id, file) for file in file_list]
     return {FileActionListTag: file_action_list}
 
-def cleanup_public_assets_bucket(log, s3_client, s3_paginator, bucket_id, prefix, dataset_id, version_id = None):
-    log.info(f"cleanup_public_assets_bucket() bucket_id: {bucket_id} prefix: {prefix} dataset_id: {dataset_id} version_id: {version_id}")
+
+def cleanup_public_assets_bucket(log, s3_client, s3_paginator, bucket_id, prefix, dataset_id, version_id=None):
+    log.info(
+        f"cleanup_public_assets_bucket() bucket_id: {bucket_id} prefix: {prefix} dataset_id: {dataset_id} version_id: {version_id}")
     dataset_assets_prefix = public_assets_prefix(prefix, dataset_id, version_id)
     delete(s3_client, s3_paginator, bucket_id, dataset_assets_prefix)
+
 
 def get_list_of_files(log, s3_client, bucket_id, prefix):
     '''
@@ -433,9 +464,11 @@ def get_list_of_files(log, s3_client, bucket_id, prefix):
     log.info(f"get_list_of_files() bucket_id: {bucket_id} prefix: {prefix}")
     paginator = s3_client.get_paginator('list_object_versions')
     bucket_listing = [file
-                      for page in paginator.paginate(Bucket=bucket_id, Prefix=prefix, PaginationConfig={'PageSize': 1000})
+                      for page in
+                      paginator.paginate(Bucket=bucket_id, Prefix=prefix, PaginationConfig={'PageSize': 1000})
                       for file in page.get("Versions", []) if file.get("IsLatest")]
     return bucket_listing
+
 
 def remove_file(log, s3_client, bucket_id, file):
     '''
@@ -457,6 +490,7 @@ def remove_file(log, s3_client, bucket_id, file):
         "versionId": version
     }
 
+
 def delete_all_versions(log, s3_client, bucket_id, dataset_id):
     log.info(f"delete_all_versions() bucket_id: {bucket_id} dataset_id: {dataset_id}")
 
@@ -468,7 +502,7 @@ def delete_all_versions(log, s3_client, bucket_id, dataset_id):
     # delete all the files
     for page in pages:
         for o in page.get("DeleteMarkers", []) + page.get("Versions", []):
-            key = o.get("Key","")
+            key = o.get("Key", "")
             folder = key[-1] == '/'
             if folder:
                 # object is a folder, put it on a list to delete at the end
@@ -484,6 +518,7 @@ def delete_all_versions(log, s3_client, bucket_id, dataset_id):
         key = o.get("Key")
         version = o.get("VersionId")
         delete_object_version(s3_client, bucket_id, key, version)
+
 
 def delete_dataset_assets(log, s3_client, s3_bucket, dataset_id):
     '''
@@ -508,6 +543,7 @@ def delete_dataset_assets(log, s3_client, s3_bucket, dataset_id):
                 s3_version = manifest.get("s3VersionId")
                 delete_object_version(s3_client, s3_bucket, s3_key, s3_version)
 
+
 def delete_graph_assets(log, s3_client, s3_bucket, dataset_id):
     '''
     This will delete versions of the graph assets (schemas, models, records) that were copied to the S3 bucket.
@@ -529,6 +565,7 @@ def delete_graph_assets(log, s3_client, s3_bucket, dataset_id):
                 s3_key = s3_key_path(dataset_id, s3_path)
                 s3_version = manifest.get("s3VersionId")
                 delete_object_version(s3_client, s3_bucket, s3_key, s3_version)
+
 
 def undo_actions(log, s3_client, bucket_id, dataset_id):
     '''
@@ -559,14 +596,17 @@ def undo_actions(log, s3_client, bucket_id, dataset_id):
         else:
             log.info(f"undo_actions() invalid file_action: {file_action}")
 
+
 def valid_file_action(file_action):
     return all([field in file_action for field in FileActionRequiredFields])
+
 
 def tidy_publication_directory(log, s3_client, s3_bucket_id, s3_key_prefix):
     log.info(f"tidy_publication_directory() s3_bucket_id: {s3_bucket_id} s3_key_prefix: {s3_key_prefix}")
     for file_name in PublishingIntermediateFiles:
         s3_key = s3_key_path(s3_key_prefix, file_name)
         delete_all_object_versions(log, s3_client, s3_bucket_id, s3_key)
+
 
 def undo_copy(log, s3_client, file_action):
     log.info(f"undo_copy() file_action: {file_action}")
@@ -582,6 +622,7 @@ def undo_copy(log, s3_client, file_action):
     else:
         restore_version(log, s3_client, s3_bucket, s3_key, s3_version)
 
+
 def undo_keep(log, s3_client, file_action):
     log.info(f"undo_keep() file_action: {file_action}")
     s3_bucket = file_action.get(FileActionBucketTag)
@@ -589,12 +630,14 @@ def undo_keep(log, s3_client, file_action):
     s3_version = file_action.get(FileActionVersionTag)
     restore_version(log, s3_client, s3_bucket, s3_key, s3_version)
 
+
 def undo_delete(log, s3_client, file_action):
     log.info(f"undo_delete() file_action: {file_action}")
     s3_bucket = file_action.get(FileActionBucketTag)
     s3_key = file_action.get(FileActionPathTag)
     s3_version = file_action.get(FileActionVersionTag)
     restore_version(log, s3_client, s3_bucket, s3_key, s3_version)
+
 
 def restore_version(log, s3_client, s3_bucket, s3_key, s3_version):
     log.info(f"restore_version() bucket: {s3_bucket} key: {s3_key} version: {s3_version}")
@@ -613,20 +656,24 @@ def restore_version(log, s3_client, s3_bucket, s3_key, s3_version):
                 log.info(f"restore_version() removing version: {latest_version}")
                 delete_object_version(s3_client, s3_bucket, s3_key, latest_version)
     else:
-        log.info(f"restore_version() cannot restore without a valid object version (bucket: {s3_bucket} key: {s3_key} version: {s3_version})")
+        log.info(
+            f"restore_version() cannot restore without a valid object version (bucket: {s3_bucket} key: {s3_key} version: {s3_version})")
+
 
 def get_object_versions(s3_client, s3_bucket, s3_key):
     response = s3_client.list_object_versions(Bucket=s3_bucket, Prefix=s3_key)
     versions = extract_versions(response)
     return versions
 
+
 def extract_versions(response):
     # extract Delete Markers and Versions from the response
-    versions = (response.get(S3DeleteMarkersTag,[]) + response.get(S3VersionsTag,[]))
+    versions = (response.get(S3DeleteMarkersTag, []) + response.get(S3VersionsTag, []))
     # sort the Versions by timestamp (most recent to oldest)
-    versions.sort(key = lambda x:x[S3LastModifiedTag])
+    versions.sort(key=lambda x: x[S3LastModifiedTag])
     versions.reverse()
     return versions
+
 
 def find_latest_version(versions):
     latest_list = []
@@ -638,8 +685,10 @@ def find_latest_version(versions):
     else:
         return None
 
+
 def is_latest(item):
     return item.get(S3IsLatestTag, False)
+
 
 def write_json_file_to_s3(log, s3_client, bucket, key, json_data):
     log.info(f"write_json_file_to_s3() bucket: {bucket} key: {bucket}")
@@ -649,6 +698,7 @@ def write_json_file_to_s3(log, s3_client, bucket, key, json_data):
         Key=key
     )
     # TODO: check response for success/failure
+
 
 def load_json_file_from_s3(log, s3_client, s3_bucket, s3_key):
     '''
@@ -672,6 +722,7 @@ def load_json_file_from_s3(log, s3_client, s3_bucket, s3_key):
     json_file = json.loads(s3_object["Body"].read())
     return json_file
 
+
 def load_dataset_file_actions(log, s3_client, bucket_id, dataset_id):
     '''
     Loads files from the publishing S3 bucket that contain FileActionItem (copy, keep, delete), from publishing and revision cleanup.
@@ -682,8 +733,9 @@ def load_dataset_file_actions(log, s3_client, bucket_id, dataset_id):
     :return: combined List of File Actions
     '''
     return load_file_actions(log, s3_client, bucket_id, dataset_id, FileActionKey) + \
-           load_file_actions(log, s3_client, bucket_id, dataset_id, RevisionsCleanupKey) + \
-           load_file_actions(log, s3_client, bucket_id, dataset_id, MetadataCleanupKey)
+        load_file_actions(log, s3_client, bucket_id, dataset_id, RevisionsCleanupKey) + \
+        load_file_actions(log, s3_client, bucket_id, dataset_id, MetadataCleanupKey)
+
 
 def load_file_actions(log, s3_client, bucket_id, dataset_id, file_action_key):
     '''
@@ -704,6 +756,7 @@ def load_file_actions(log, s3_client, bucket_id, dataset_id, file_action_key):
         log.info(f"load_file_actions() NotFound bucket_id: {bucket_id} dataset_id: {dataset_id} s3_key: {s3_key}")
         return []
 
+
 def delete_all_object_versions(log, s3_client, s3_bucket, s3_key):
     log.info(f"delete_all_object_versions() bucket: {s3_bucket} key: {s3_key}")
     versions = get_object_versions(s3_client, s3_bucket, s3_key)
@@ -715,18 +768,22 @@ def delete_all_object_versions(log, s3_client, s3_bucket, s3_key):
             else:
                 delete_object_version(s3_client, s3_bucket, s3_key, s3_version)
 
+
 def delete_object(log, s3_client, s3_bucket, s3_key):
     log.info(f"delete_object() s3_bucket: {s3_bucket} s3_key: {s3_key}")
     s3_client.delete_object(Bucket=s3_bucket, Key=s3_key)
 
+
 def delete_object_version(s3_client, s3_bucket, s3_key, s3_version):
     s3_client.delete_object(Bucket=s3_bucket, Key=s3_key, VersionId=s3_version)
 
+
 def public_assets_prefix(prefix, dataset_id, version_id):
     if version_id is None:
-        return f"{prefix}/{dataset_id}"
+        return f"{prefix}/{dataset_id}/"
     else:
-        return f"{prefix}/{dataset_id}/{version_id}"
+        return f"{prefix}/{dataset_id}/{version_id}/"
+
 
 def s3_key_path(prefix, suffix):
     separator = "" if prefix.endswith("/") else "/"

--- a/main.py
+++ b/main.py
@@ -225,7 +225,7 @@ def lambda_handler(event, context, s3_client=S3Client, s3_paginator=S3ClientPagi
 
         publish_bucket_id = event['publish_bucket']
         embargo_bucket_id = event['embargo_bucket']
-        s3_key_prefix = event['s3_key_prefix']
+        s3_key_prefix = event.get('s3_key_prefix', "-1")
         cleanup_stage = event.get("cleanup_stage", CleanupStageInitial)
         workflow_id = int(event.get("workflow_id", "4"))
         dataset_id = event.get("published_dataset_id","-1")

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,4 +1,0 @@
-[pytest]
-filterwarnings =
-# deprecation warning from third party code
-    ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working:DeprecationWarning:botocore:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-structlog==19.1.0
+structlog==25.4.0

--- a/test.py
+++ b/test.py
@@ -245,7 +245,7 @@ def test_cleanup_state_tidy(publish_bucket, embargo_bucket):
 
     # RUN LAMBDA
     lambda_handler({
-        's3_key_prefix': S3_PREFIX_TO_DELETE,
+        'published_dataset_id': S3_PREFIX_TO_DELETE,
         'publish_bucket': PUBLISH_BUCKET,
         'embargo_bucket': EMBARGO_BUCKET,
         'workflow_id': '5',
@@ -299,7 +299,6 @@ def test_cleanup_state_unpublish(publish_bucket, embargo_bucket, asset_bucket):
 
     # RUN LAMBDA
     lambda_handler({
-        's3_key_prefix': S3_PREFIX_TO_DELETE,
         'published_dataset_id': S3_PREFIX_TO_DELETE,
         'publish_bucket': PUBLISH_BUCKET,
         'embargo_bucket': EMBARGO_BUCKET,
@@ -340,7 +339,6 @@ def test_cleanup_state_failure(publish_bucket, embargo_bucket, asset_bucket):
     assert s3_keys(asset_bucket) == asset_keys.union(asset_keys_to_keep)
 
     lambda_handler({
-        's3_key_prefix': S3_PREFIX_TO_DELETE,
         'published_dataset_id': S3_PREFIX_TO_DELETE,
         'published_dataset_version': dataset_version,
         'publish_bucket': PUBLISH_BUCKET,
@@ -442,7 +440,6 @@ def test_undo_copy_on_failure(publish_bucket, embargo_bucket, asset_bucket):
     assert s3_keys(embargo_bucket) == created_keys
 
     lambda_handler({
-        's3_key_prefix': S3_PREFIX_TO_DELETE,
         'published_dataset_id': S3_PREFIX_TO_DELETE,
         'published_dataset_version': dataset_version,
         'publish_bucket': PUBLISH_BUCKET,
@@ -502,7 +499,6 @@ def test_undo_keep_on_failure(publish_bucket, embargo_bucket, asset_bucket):
     assert s3_keys(publish_bucket) == created_keys
 
     lambda_handler({
-        's3_key_prefix': S3_PREFIX_TO_DELETE,
         'published_dataset_id': S3_PREFIX_TO_DELETE,
         'published_dataset_version': dataset_version,
         'publish_bucket': PUBLISH_BUCKET,
@@ -592,7 +588,6 @@ def test_undo_delete_on_failure(publish_bucket, embargo_bucket, asset_bucket):
     assert s3_keys(publish_bucket) == expected_pre_clean_keys
 
     lambda_handler({
-        's3_key_prefix': S3_PREFIX_TO_DELETE,
         'published_dataset_id': S3_PREFIX_TO_DELETE,
         'published_dataset_version': dataset_version,
         'publish_bucket': PUBLISH_BUCKET,

--- a/test.py
+++ b/test.py
@@ -332,7 +332,7 @@ def test_cleanup_state_unpublish(publish_bucket, embargo_bucket, asset_bucket):
 
 # this does not test the handling of file actions
 def test_cleanup_state_failure(publish_bucket, embargo_bucket, asset_bucket):
-    dataset_version = 1
+    dataset_version = "1"
 
     publish_keys, asset_keys = create_publish_files(publish_bucket,
                                                     embargo_bucket,
@@ -367,7 +367,7 @@ def test_cleanup_state_failure(publish_bucket, embargo_bucket, asset_bucket):
 
 def test_undo_copy_on_failure(publish_bucket, embargo_bucket, asset_bucket):
     dataset_id = DATASET_TO_DELETE
-    dataset_version = 2
+    dataset_version = "2"
 
     created_keys = set()
     file_action_key = '{}/{}'.format(dataset_id, FileActionKey)
@@ -477,7 +477,7 @@ def test_undo_copy_on_failure(publish_bucket, embargo_bucket, asset_bucket):
 # a keep file action in an embargoed publish.
 def test_undo_keep_on_failure(publish_bucket, embargo_bucket, asset_bucket):
     dataset_id = DATASET_TO_DELETE
-    dataset_version = 2
+    dataset_version = "2"
 
     created_keys = set()
     file_action_key = '{}/{}'.format(dataset_id, FileActionKey)
@@ -536,7 +536,7 @@ def test_undo_keep_on_failure(publish_bucket, embargo_bucket, asset_bucket):
 # a delete file action in an embargoed publish.
 def test_undo_delete_on_failure(publish_bucket, embargo_bucket, asset_bucket):
     dataset_id = DATASET_TO_DELETE
-    dataset_version = 3
+    dataset_version = "3"
 
     expected_pre_clean_keys = set()
     file_action_key = '{}/{}'.format(dataset_id, FileActionKey)

--- a/test.py
+++ b/test.py
@@ -387,6 +387,8 @@ def test_undo_copy_on_failure(publish_bucket, embargo_bucket, asset_bucket):
 
     embargo_bucket.upload_file(FILENAME, copied_key)
 
+    # TODO add another file to test the case where the copy did not yet happen before the failure
+
     embargo_bucket_file_actions = json.dumps({
         FileActionListTag: [
             {
@@ -532,6 +534,7 @@ def test_undo_delete_on_failure(publish_bucket, embargo_bucket, asset_bucket):
     assert deleted_vdelete_marker != deleted_v1
     assert deleted_vdelete_marker != deleted_v2
 
+    # TODO turn this into a delete-marker test
     delete_marker_obj = publish_bucket.Object(deleted_key)
     try:
         delete_marker_obj.load()
@@ -540,6 +543,7 @@ def test_undo_delete_on_failure(publish_bucket, embargo_bucket, asset_bucket):
         print(response_metadata['HTTPStatusCode'])
         print(response_metadata['HTTPHeaders'])
 
+    # TODO add another test file for case where the delete did not yet happen.
     publish_bucket_file_actions = json.dumps({
         FileActionListTag: [
             {

--- a/test.py
+++ b/test.py
@@ -32,11 +32,15 @@ ASSET_BUCKET = 'test-discover-assets'
 DATASET_ASSETS_KEY_PREFIX = 'dataset-assets'
 
 # This key corresponds to assets belonging to a dataset
-# that is either being unpublished or was not published successfully
+# that is either being unpublished or was not published successfully.
+# Chosen to be a substring prefix of DATASET_TO_KEEP so that tests catch missing
+# final '/'s which will lead paginator-based deletes to delete more than we want.
 DATASET_TO_DELETE = '11'
 
 # This key corresponds to assets belonging to a dataset version
-# that should remain untouched by this lambda function
+# that should remain untouched by this lambda function.
+# Chosen to contain f DATASET_TO_DELETE as a prefix so that tests catch missing
+# final '/'s which will lead paginator-based deletes to delete more than we want.
 DATASET_TO_KEEP = '111'
 
 # This is a dummy file


### PR DESCRIPTION
Primary aim is to address https://app.clickup.com/t/86893frgc where files are not being deleted from S3 during unpublish. This ends up being more of a discover-service issue, but there are a couple of bugs addressed in this S3Clean Lambda.

- Fixes a bug in S3Paginator where wrong paginator is being used if a clean up action uses both `list_object_versions` and `list_objects_v2`.
- Fixes `public_assets_prefix()` so that returned prefix ends with `/` to avoid deleting more objects than desired.
- Adds tests for v5 cleanup
- Draws strict distinction between which of the parameters `'s3_key_prefix'`, `'published_dataset_id'`, and `'published_dataset_version'` are required by v4 cleanup and v5. V4 will require only `'s3_key_prefix'` and v5 will require only `'published_dataset_id'` and `'published_dataset_version'` with the latter only required during a Failure cleanup.
- Updates version of Python to 3.12 in build and test container to match the Lambda runtime version.
- Updates botocore version.
- Updates localstack version to get correct delete marker behaviour.
- Re-activates tests in Jenkinsfile.
- Refactors tests a little to allow them be run locally by a dev.
