### PR TITLE
Fix prefix for cleanup_dataset_folders

### DIFF
--- a/main.py
+++ b/main.py
@@ -427,7 +427,7 @@ def cleanup_dataset_metadata(log, s3_client, s3_clean_config):
 def cleanup_dataset_folders(log, s3_client, bucket_list, dataset_id, folder_prefix, folder_cleanup_key):
     log.info(
         f"cleanup_dataset_folders() dataset_id: {dataset_id} folder_prefix: {folder_prefix} folder_cleanup_key: {folder_cleanup_key} bucket_list: {bucket_list}")
-    key_prefix = f"{dataset_id}/{folder_prefix}"
+    key_prefix = f"{dataset_id}/{folder_prefix}/"
     cleanup_file = f"{dataset_id}/{folder_cleanup_key}" if folder_cleanup_key is not None else None
     cleanup_buckets(log,
                     s3_client,


### PR DESCRIPTION
When searching for files in the `metadata` and `revisions` sub-directories, the key prefix should include a final `'/'` to make sure they only list files in those "directories" and not a file that happens to start with `metadata` for example. 

In practice, I don't think this is an issue unless we start including files that start with `metadata` or 'revisions` to the published dataset in the root directory. 