### PR TITLE
Pin localstack to final community edition

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,7 +16,7 @@ services:
       AWS_DEFAULT_REGION: 'us-east-1'
 
   localstack:
-    image: localstack/localstack:s3-latest
+    image: localstack/localstack:s3-community-archive
     environment:
       - MAIN_CONTAINER_NAME=localstack
     expose:


### PR DESCRIPTION
PR pins localstack image to final community edition to avoid failing tests until we work out our LocalStack situation.